### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ bitcoin: 12vHS4h6patf4Ne6og4BHcDxRma3g2URUK  <br>
 <br>
 `cd /tmp/ && wget https://github.com/crack00r/Flexget-Config/archive/master.zip`<br>
 `unzip  master.zip`<br>
-`mkdir ~/.flexget && cp -r master/* ~/.flexget/`<br>
+`mkdir ~/.flexget && cp -r *master/* ~/.flexget/`<br>
 
 `flexget trakt auth USER`<br>
 


### PR DESCRIPTION
Nur ein kleiner Fehler...

cp: cannot stat 'master/*': No such file or directory
Der Ordner heißt Flexget-Config-master und mit dem *master kann man einfach den Ordner kopieren lassen obwohl er nicht Flexget-Config-master angegeben ist im cp Befehl